### PR TITLE
The state folder now respects the actual location of the plugins folder

### DIFF
--- a/name2color.py
+++ b/name2color.py
@@ -34,7 +34,18 @@ parser.add_argument('--clear', action='store_true')
 parser.add_argument('--show-state', action='store_true')
 args = parser.parse_args()
 
-state_prefix = os.path.expanduser("~/.tmux/plugins/tmux-colortag/state")
+tmux_plugins_path = ""
+try_plugin_paths = [os.environ["TMUX_PLUGIN_MANAGER_PATH"], os.path.join(os.environ["XDG_CONFIG_HOME"], "tmux/plugins")]
+for plugin_path in [os.path.expanduser(path) for path in try_plugin_paths]:
+    if os.path.exists(plugin_path):
+        tmux_plugins_path = plugin_path
+        break
+
+if tmux_plugins_path == "":
+    tmux_plugins_path = "~/.tmux/plugins"
+
+state_prefix = os.path.join(tmux_plugins_path, "tmux-colortag/state")
+    
 state = {}
 changed = True
 


### PR DESCRIPTION
The following locations are checked:
1. `$TMUX_PLUGIN_MANAGER_PATH`
2. `$XDG_CONFIG_HOME/tmux/plugins`

If none of the above exist, we fall back to the previous default `~/.tmux/plugins`